### PR TITLE
カード表示領域をdivタグからcanvasタグに変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,9 +9,9 @@
 <body>
     <div class="container">
         <h1>トランプカード</h1>
-        <div id="card-container" class="card-container">
+        <canvas id="card-container" class="card-container" width="800" height="250">
             <!-- カードがここに動的に表示されます -->
-        </div>
+        </canvas>
         <button id="shuffle-btn" class="shuffle-btn">カードをシャッフル</button>
     </div>
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -33,28 +33,56 @@ function shuffleDeck(deck) {
     return shuffled;
 }
 
-// カードのHTML要素を作成
-function createCardElement(card) {
-    const cardDiv = document.createElement('div');
-    cardDiv.className = `card ${card.suit}`;
+// カードをcanvasに描画
+function drawCard(ctx, card, x, y, width, height) {
+    // カードの背景
+    ctx.fillStyle = 'white';
+    ctx.strokeStyle = '#333';
+    ctx.lineWidth = 2;
 
-    const topDiv = document.createElement('div');
-    topDiv.className = 'card-top';
-    topDiv.textContent = `${card.rank}${card.symbol}`;
+    // 角丸の矩形を描画
+    const radius = 10;
+    ctx.beginPath();
+    ctx.moveTo(x + radius, y);
+    ctx.lineTo(x + width - radius, y);
+    ctx.quadraticCurveTo(x + width, y, x + width, y + radius);
+    ctx.lineTo(x + width, y + height - radius);
+    ctx.quadraticCurveTo(x + width, y + height, x + width - radius, y + height);
+    ctx.lineTo(x + radius, y + height);
+    ctx.quadraticCurveTo(x, y + height, x, y + height - radius);
+    ctx.lineTo(x, y + radius);
+    ctx.quadraticCurveTo(x, y, x + radius, y);
+    ctx.closePath();
+    ctx.fill();
+    ctx.stroke();
 
-    const centerDiv = document.createElement('div');
-    centerDiv.className = 'card-center';
-    centerDiv.textContent = card.symbol;
+    // カードの色を設定
+    const color = (card.suit === 'hearts' || card.suit === 'diamonds') ? '#e74c3c' : '#2c3e50';
+    ctx.fillStyle = color;
 
-    const bottomDiv = document.createElement('div');
-    bottomDiv.className = 'card-bottom';
-    bottomDiv.textContent = `${card.rank}${card.symbol}`;
+    // 上部のランクとスート
+    ctx.font = 'bold 20px Arial';
+    ctx.fillText(`${card.rank}${card.symbol}`, x + 10, y + 25);
 
-    cardDiv.appendChild(topDiv);
-    cardDiv.appendChild(centerDiv);
-    cardDiv.appendChild(bottomDiv);
+    // 中央のスート
+    ctx.font = '60px Arial';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(card.symbol, x + width / 2, y + height / 2);
 
-    return cardDiv;
+    // 下部のランクとスート（回転）
+    ctx.save();
+    ctx.translate(x + width - 10, y + height - 25);
+    ctx.rotate(Math.PI);
+    ctx.font = 'bold 20px Arial';
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'alphabetic';
+    ctx.fillText(`${card.rank}${card.symbol}`, 0, 0);
+    ctx.restore();
+
+    // テキスト設定をリセット
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'alphabetic';
 }
 
 // カードを表示
@@ -63,24 +91,24 @@ function displayCards() {
     const shuffled = shuffleDeck(deck);
     const selectedCards = shuffled.slice(0, 4); // 4枚のカードを選択
 
-    const container = document.getElementById('card-container');
-    container.innerHTML = ''; // 既存のカードをクリア
+    const canvas = document.getElementById('card-container');
+    const ctx = canvas.getContext('2d');
 
+    // canvasをクリア
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    // カードのサイズと配置
+    const cardWidth = 140;
+    const cardHeight = 200;
+    const gap = 20;
+    const startX = (canvas.width - (cardWidth * 4 + gap * 3)) / 2;
+    const startY = (canvas.height - cardHeight) / 2;
+
+    // 各カードを描画
     selectedCards.forEach((card, index) => {
-        const cardElement = createCardElement(card);
-        // アニメーション用の遅延を追加
-        setTimeout(() => {
-            cardElement.style.opacity = '0';
-            cardElement.style.transform = 'translateY(20px)';
-            container.appendChild(cardElement);
-
-            // フェードインアニメーション
-            setTimeout(() => {
-                cardElement.style.transition = 'all 0.5s ease';
-                cardElement.style.opacity = '1';
-                cardElement.style.transform = 'translateY(0)';
-            }, 10);
-        }, index * 100);
+        const x = startX + (cardWidth + gap) * index;
+        const y = startY;
+        drawCard(ctx, card, x, y, cardWidth, cardHeight);
     });
 }
 

--- a/style.css
+++ b/style.css
@@ -32,59 +32,10 @@ h1 {
 }
 
 .card-container {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    gap: 20px;
-    margin: 30px 0;
-    flex-wrap: wrap;
-}
-
-.card {
-    width: 140px;
-    height: 200px;
-    background: white;
-    border: 2px solid #333;
+    display: block;
+    margin: 30px auto;
     border-radius: 10px;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    padding: 10px;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
-    cursor: pointer;
-    position: relative;
-}
-
-.card:hover {
-    transform: translateY(-10px) scale(1.05);
-    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.3);
-}
-
-.card.hearts, .card.diamonds {
-    color: #e74c3c;
-}
-
-.card.clubs, .card.spades {
-    color: #2c3e50;
-}
-
-.card-top, .card-bottom {
-    font-size: 1.5em;
-    font-weight: bold;
-}
-
-.card-bottom {
-    text-align: right;
-    transform: rotate(180deg);
-}
-
-.card-center {
-    font-size: 4em;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex: 1;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
 
 .shuffle-btn {
@@ -111,16 +62,11 @@ h1 {
 }
 
 @media (max-width: 768px) {
-    .card {
-        width: 120px;
-        height: 170px;
-    }
-
-    .card-center {
-        font-size: 3em;
-    }
-
     h1 {
         font-size: 2em;
+    }
+
+    .card-container {
+        max-width: 100%;
     }
 }


### PR DESCRIPTION
## 概要

カード表示領域 `card-container` をdivタグからcanvasタグに変更し、トランプカードが画像として表示されるようにしました。

## 変更内容

- index.htmlのcard-containerをcanvasタグに変更
- script.jsにcanvas描画ロジック(drawCard関数)を実装
- displayCards関数をcanvas描画に対応
- 不要な.card関連のCSSスタイルを削除

Fixes #6

🤖 Generated with [Claude Code](https://claude.ai/code)