### PR TITLE
背景をカジノのラシャ風の緑色に変更

### DIFF
--- a/style.css
+++ b/style.css
@@ -6,7 +6,7 @@
 
 body {
     font-family: 'Arial', sans-serif;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: #0a5e0a;
     min-height: 100vh;
     display: flex;
     justify-content: center;
@@ -16,7 +16,7 @@ body {
 
 .container {
     text-align: center;
-    background: rgba(255, 255, 255, 0.95);
+    background: #0a5e0a;
     padding: 40px;
     border-radius: 20px;
     box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
@@ -25,10 +25,10 @@ body {
 }
 
 h1 {
-    color: #333;
+    color: #fff;
     margin-bottom: 30px;
     font-size: 2.5em;
-    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
+    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
 }
 
 .card-container {
@@ -36,6 +36,7 @@ h1 {
     margin: 30px auto;
     border-radius: 10px;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    background: #0a5e0a;
 }
 
 .shuffle-btn {


### PR DESCRIPTION
## 概要

bodyタグ、containerクラス、card-containerクラスの背景色をカジノのラシャのような緑色（#0a5e0a）に変更しました。

## 変更内容

- bodyの背景色を`#0a5e0a`に変更
- containerクラスの背景色を`#0a5e0a`に変更
- card-containerクラスの背景色を`#0a5e0a`に追加
- h1の文字色を白に変更して視認性を向上

Closes #8

🤖 Generated with [Claude Code](https://claude.ai/code)