### PR TITLE
当り機能の追加

### DIFF
--- a/atari.yml
+++ b/atari.yml
@@ -1,0 +1,29 @@
+# 当り条件の定義
+# スート: hearts, diamonds, clubs, spades, または null (未指定)
+# 数字: 具体的な値、または null (未指定)
+# 色: red, black, または null (未指定)
+
+atari_conditions:
+  - name: "フォーカード"
+    description: "フォーカード"
+    suit: null  # 未指定
+    rank_condition: "all_same"  # 全て同じ数字
+    color: null  # 未指定
+
+  - name: "当日"
+    description: "今日の日付"
+    suit: null  # 未指定
+    rank_condition: "current_date"  # 現在日と同じ並び
+    color: null  # 未指定
+
+  - name: "オールブラック"
+    description: "全て黒"
+    suit: null  # 未指定
+    rank_condition: null  # 未指定
+    color: "black"  # 全て黒
+
+  - name: "オールレッド"
+    description: "全て赤"
+    suit: null  # 未指定
+    rank_condition: null  # 未指定
+    color: "red"  # 全て赤

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <body>
     <div class="container">
         <h1>トランプカード</h1>
-        <canvas id="card-container" class="card-container" width="800" height="250">
+        <canvas id="card-container" class="card-container" width="800" height="320">
             <!-- カードがここに動的に表示されます -->
         </canvas>
         <button id="shuffle-btn" class="shuffle-btn">カードをシャッフル</button>


### PR DESCRIPTION
#4枚のカードが特定の条件になったとき、当りを表示する機能を実装しました。

## 変更内容
- atari.yml: 当り条件の定義ファイルを作成
- script.js: 当り判定ロジックと表示機能を追加
- index.html: Canvasの高さを調整

## 実装した当り条件
1. フォーカード: 全て同じ数字
2. 当日: 現在日と同じ並び
3. オールブラック: 全て黒
4. オールレッド: 全て赤

Closes #12

🤖 Generated with [Claude Code](https://claude.ai/code)