### PR TITLE
canvasタグに描画した画像をimgタグに変換する

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
         <canvas id="card-container" class="card-container" width="800" height="320">
             <!-- カードがここに動的に表示されます -->
         </canvas>
+        <img id="card-image" style="display: block;" class="card-container" alt="カード画像">
         <button id="shuffle-btn" class="shuffle-btn">カードをシャッフル</button>
         <div id="atari-buttons" class="atari-buttons">
             <button id="retry-btn" class="retry-btn" style="display: none;">もう一度回す</button>

--- a/script.js
+++ b/script.js
@@ -221,6 +221,9 @@ function displayCards() {
         // ハズレ時の処理（ボタンを通常状態に戻す）
         handleHazure();
     }
+
+    // canvasをimgタグに変換
+    convertCanvasToImage();
 }
 
 // 当たり時の処理
@@ -266,6 +269,21 @@ function retryGacha() {
 
     // カードをシャッフル
     displayCards();
+}
+
+// canvasをimgタグに変換
+function convertCanvasToImage() {
+    const canvas = document.getElementById('card-container');
+    const img = document.getElementById('card-image');
+
+    // canvasの内容をData URLとして取得
+    const dataURL = canvas.toDataURL('image/png');
+
+    // imgタグにData URLを設定
+    img.src = dataURL;
+
+    // canvasを非表示にする
+    canvas.style.display = 'none';
 }
 
 // 当り表示を描画


### PR DESCRIPTION
Issue #35 の対応

canvasタグに描画した画像をimgタグに変換する機能を実装しました。

### 変更内容
- index.htmlにimgタグ(id="card-image")を追加
- imgタグにstyle="display: block;"を設定
- script.jsにconvertCanvasToImage()関数を追加
- canvasの内容をtoDataURL()でData URLに変換しimgタグに設定
- canvas要素をdisplay: noneで非表示にする処理を実装

Generated with [Claude Code](https://claude.ai/code)